### PR TITLE
Restore post-quantum cryptography section in docs

### DIFF
--- a/docs/docs/security/cryptography.md
+++ b/docs/docs/security/cryptography.md
@@ -111,6 +111,16 @@ Sensitive data is handled carefully:
 
 zopp has not yet undergone a formal security audit. The cryptographic design follows established best practices and uses standard, well-audited libraries.
 
+## Future Considerations
+
+### Post-Quantum Cryptography
+
+Current algorithms (Ed25519, X25519) are vulnerable to quantum computers. When PQC standards mature:
+- Key encapsulation: ML-KEM (Kyber)
+- Signatures: ML-DSA (Dilithium) or SLH-DSA (SPHINCS+)
+
+zopp's architecture allows upgrading algorithms without changing the security model.
+
 ## Next Steps
 
 - [Architecture](/security/architecture) - How these primitives are used


### PR DESCRIPTION
## Summary
- Restores the "Future Considerations" section about post-quantum cryptography that was accidentally removed during the Starlight to Docusaurus migration (commit 902adf4)
- Documents plans for ML-KEM (Kyber), ML-DSA (Dilithium), and SLH-DSA (SPHINCS+) when PQC standards mature

## Context
The original section existed in commit 2688c3c (Starlight docs) but was lost in the migration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the “Future Considerations” docs section on post-quantum cryptography that was removed during the Starlight → Docusaurus migration. Clarifies planned adoption of ML-KEM (Kyber) for key encapsulation and ML-DSA (Dilithium) or SLH-DSA (SPHINCS+) for signatures, and notes the architecture supports algorithm upgrades.

<sup>Written for commit 22b8bece437961b5a9f89c64a092c94122e1ab38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

