### PR TITLE
Add audit CLI commands with E2E and RBAC tests

### DIFF
--- a/apps/e2e-tests/tests/audit.rs
+++ b/apps/e2e-tests/tests/audit.rs
@@ -1,0 +1,262 @@
+//! Audit log E2E tests
+//!
+//! Tests audit CLI commands: list, get, count.
+//! Audit logs require Admin workspace permission.
+
+#[macro_use]
+mod common;
+
+use common::{BackendConfig, TestHarness};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Audit Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+backend_test!(test_audit_list_after_operations, run_test_audit_list);
+backend_test!(test_audit_count, run_test_audit_count);
+backend_test!(test_audit_get_by_id, run_test_audit_get_by_id);
+backend_test!(test_audit_filter_by_action, run_test_audit_filter_by_action);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test Implementations
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Test that audit logs are recorded for operations and can be listed
+async fn run_test_audit_list(config: BackendConfig) -> Result<(), Box<dyn std::error::Error>> {
+    let harness = TestHarness::new("audit_list", config).await?;
+
+    // Setup: create user and workspace
+    let invite = harness.create_server_invite()?;
+    let alice = harness.create_user("alice");
+    alice.join(&invite, &alice.email(), &alice.principal())?;
+    alice.exec(&["workspace", "create", "testws"]).success()?;
+    alice
+        .exec(&["project", "create", "api", "-w", "testws"])
+        .success()?;
+    alice
+        .exec(&["environment", "create", "dev", "-w", "testws", "-p", "api"])
+        .success()?;
+
+    // Perform some operations that should be recorded in audit logs
+    println!("  Test 1: Perform operations to generate audit entries...");
+    alice
+        .exec(&[
+            "secret",
+            "set",
+            "-w",
+            "testws",
+            "-p",
+            "api",
+            "-e",
+            "dev",
+            "API_KEY",
+            "secret123",
+        ])
+        .success()?;
+    alice
+        .exec(&[
+            "secret", "get", "-w", "testws", "-p", "api", "-e", "dev", "API_KEY",
+        ])
+        .success()?;
+    alice
+        .exec(&[
+            "secret", "delete", "-w", "testws", "-p", "api", "-e", "dev", "API_KEY",
+        ])
+        .success()?;
+
+    // Test: List audit logs
+    println!("  Test 2: List audit logs...");
+    let output = alice
+        .exec(&["audit", "list", "-w", "testws", "--limit", "50"])
+        .success()?;
+
+    // Should show audit entries (the output includes ID:, Timestamp:, Action:, etc.)
+    assert!(
+        output.contains("Action:"),
+        "Expected audit log entries, got: {}",
+        output
+    );
+
+    println!("test_audit_list PASSED");
+    Ok(())
+}
+
+/// Test audit count command
+async fn run_test_audit_count(config: BackendConfig) -> Result<(), Box<dyn std::error::Error>> {
+    let harness = TestHarness::new("audit_count", config).await?;
+
+    // Setup
+    let invite = harness.create_server_invite()?;
+    let alice = harness.create_user("alice");
+    alice.join(&invite, &alice.email(), &alice.principal())?;
+    alice.exec(&["workspace", "create", "testws"]).success()?;
+    alice
+        .exec(&["project", "create", "api", "-w", "testws"])
+        .success()?;
+    alice
+        .exec(&["environment", "create", "dev", "-w", "testws", "-p", "api"])
+        .success()?;
+
+    // Perform operations
+    println!("  Test 1: Perform operations...");
+    alice
+        .exec(&[
+            "secret", "set", "-w", "testws", "-p", "api", "-e", "dev", "KEY1", "val1",
+        ])
+        .success()?;
+    alice
+        .exec(&[
+            "secret", "set", "-w", "testws", "-p", "api", "-e", "dev", "KEY2", "val2",
+        ])
+        .success()?;
+
+    // Test: Count audit logs
+    println!("  Test 2: Count audit logs...");
+    let output = alice.exec(&["audit", "count", "-w", "testws"]).success()?;
+
+    // Should show "Total audit log entries: N" where N > 0
+    assert!(
+        output.contains("Total audit log entries:"),
+        "Expected count output, got: {}",
+        output
+    );
+
+    // Parse the count and verify it's > 0
+    let count_str = output
+        .split(':')
+        .next_back()
+        .map(|s| s.trim())
+        .unwrap_or("0");
+    let count: u32 = count_str.parse().unwrap_or(0);
+    assert!(count > 0, "Expected audit count > 0, got: {}", count);
+
+    println!("test_audit_count PASSED");
+    Ok(())
+}
+
+/// Test getting a specific audit log entry by ID
+async fn run_test_audit_get_by_id(config: BackendConfig) -> Result<(), Box<dyn std::error::Error>> {
+    let harness = TestHarness::new("audit_get", config).await?;
+
+    // Setup
+    let invite = harness.create_server_invite()?;
+    let alice = harness.create_user("alice");
+    alice.join(&invite, &alice.email(), &alice.principal())?;
+    alice.exec(&["workspace", "create", "testws"]).success()?;
+    alice
+        .exec(&["project", "create", "api", "-w", "testws"])
+        .success()?;
+    alice
+        .exec(&["environment", "create", "dev", "-w", "testws", "-p", "api"])
+        .success()?;
+
+    // Perform an operation
+    println!("  Test 1: Perform operation...");
+    alice
+        .exec(&[
+            "secret", "set", "-w", "testws", "-p", "api", "-e", "dev", "MY_KEY", "my_value",
+        ])
+        .success()?;
+
+    // List audit logs to get an ID
+    println!("  Test 2: List audit logs to get an ID...");
+    let list_output = alice
+        .exec(&["audit", "list", "-w", "testws", "--limit", "1"])
+        .success()?;
+
+    // Extract the ID from the output (format: "ID:        <uuid>")
+    let id = list_output
+        .lines()
+        .find(|line| line.starts_with("ID:"))
+        .and_then(|line| line.split_whitespace().last())
+        .ok_or("Failed to extract audit log ID from list output")?;
+
+    // Test: Get the specific audit entry
+    println!("  Test 3: Get audit entry by ID {}...", id);
+    let output = alice
+        .exec(&["audit", "get", "-w", "testws", id])
+        .success()?;
+
+    // Should show detailed entry info
+    assert!(output.contains("ID:"), "Expected ID in output");
+    assert!(
+        output.contains("Timestamp:"),
+        "Expected Timestamp in output"
+    );
+    assert!(output.contains("Action:"), "Expected Action in output");
+    assert!(output.contains(id), "Expected the requested ID in output");
+
+    println!("test_audit_get_by_id PASSED");
+    Ok(())
+}
+
+/// Test filtering audit logs by result
+async fn run_test_audit_filter_by_action(
+    config: BackendConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let harness = TestHarness::new("audit_filter", config).await?;
+
+    // Setup
+    let invite = harness.create_server_invite()?;
+    let alice = harness.create_user("alice");
+    alice.join(&invite, &alice.email(), &alice.principal())?;
+    alice.exec(&["workspace", "create", "testws"]).success()?;
+    alice
+        .exec(&["project", "create", "api", "-w", "testws"])
+        .success()?;
+    alice
+        .exec(&["environment", "create", "dev", "-w", "testws", "-p", "api"])
+        .success()?;
+
+    // Perform various operations
+    println!("  Test 1: Perform various operations...");
+    alice
+        .exec(&[
+            "secret", "set", "-w", "testws", "-p", "api", "-e", "dev", "KEY1", "val1",
+        ])
+        .success()?;
+    alice
+        .exec(&[
+            "secret", "get", "-w", "testws", "-p", "api", "-e", "dev", "KEY1",
+        ])
+        .success()?;
+    alice
+        .exec(&[
+            "secret", "set", "-w", "testws", "-p", "api", "-e", "dev", "KEY2", "val2",
+        ])
+        .success()?;
+
+    // Test: Filter by result (success)
+    println!("  Test 2: Filter audit logs by result 'success'...");
+    let output = alice
+        .exec(&["audit", "list", "-w", "testws", "--result", "success"])
+        .success()?;
+
+    // If there are results, they should all be success
+    if output.contains("Result:") {
+        for line in output.lines() {
+            if line.starts_with("Result:") {
+                assert!(
+                    line.contains("success"),
+                    "Expected only success results when filtering, got: {}",
+                    line
+                );
+            }
+        }
+    }
+
+    // Test: Count filtered entries
+    println!("  Test 3: Count audit logs filtered by result 'success'...");
+    let count_output = alice
+        .exec(&["audit", "count", "-w", "testws", "--result", "success"])
+        .success()?;
+
+    assert!(
+        count_output.contains("Total audit log entries:"),
+        "Expected count output, got: {}",
+        count_output
+    );
+
+    println!("test_audit_filter_by_result PASSED");
+    Ok(())
+}

--- a/apps/zopp-cli/src/cli.rs
+++ b/apps/zopp-cli/src/cli.rs
@@ -81,6 +81,11 @@ pub enum Command {
         #[command(subcommand)]
         group_cmd: GroupCommand,
     },
+    /// Audit log commands (admin only)
+    Audit {
+        #[command(subcommand)]
+        audit_cmd: AuditCommand,
+    },
     /// Run a command with secrets injected as environment variables
     Run {
         /// Workspace name (defaults from zopp.toml)
@@ -963,5 +968,44 @@ pub enum GroupCommand {
         /// Environment name
         #[arg(long, short = 'e')]
         environment: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AuditCommand {
+    /// List audit log entries in a workspace
+    List {
+        /// Workspace name
+        #[arg(long, short = 'w')]
+        workspace: String,
+        /// Filter by action type
+        #[arg(long)]
+        action: Option<String>,
+        /// Filter by result
+        #[arg(long)]
+        result: Option<String>,
+        /// Maximum entries to return
+        #[arg(long, default_value = "50")]
+        limit: u32,
+    },
+    /// Get a specific audit log entry
+    Get {
+        /// Workspace name
+        #[arg(long, short = 'w')]
+        workspace: String,
+        /// Audit entry ID
+        id: String,
+    },
+    /// Count audit log entries in a workspace
+    Count {
+        /// Workspace name
+        #[arg(long, short = 'w')]
+        workspace: String,
+        /// Filter by action type
+        #[arg(long)]
+        action: Option<String>,
+        /// Filter by result
+        #[arg(long)]
+        result: Option<String>,
     },
 }

--- a/apps/zopp-cli/src/commands/audit.rs
+++ b/apps/zopp-cli/src/commands/audit.rs
@@ -1,0 +1,133 @@
+//! Audit log commands: list, get, count
+
+use crate::grpc::{add_auth_metadata, setup_client};
+
+pub async fn cmd_audit_list(
+    server: &str,
+    tls_ca_cert: Option<&std::path::Path>,
+    workspace_name: &str,
+    action: Option<&str>,
+    result: Option<&str>,
+    limit: Option<u32>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (mut client, principal) = setup_client(server, tls_ca_cert).await?;
+
+    let mut request = tonic::Request::new(zopp_proto::ListAuditLogsRequest {
+        workspace_name: workspace_name.to_string(),
+        principal_id: None,
+        user_id: None,
+        project_name: None,
+        environment_name: None,
+        action: action.map(|s| s.to_string()),
+        result: result.map(|s| s.to_string()),
+        from_timestamp: None,
+        to_timestamp: None,
+        limit,
+        offset: None,
+    });
+    add_auth_metadata(&mut request, &principal, "/zopp.ZoppService/ListAuditLogs")?;
+
+    let response = client.list_audit_logs(request).await?.into_inner();
+
+    if response.entries.is_empty() {
+        println!("No audit log entries found.");
+    } else {
+        println!(
+            "Audit logs ({} of {} total):\n",
+            response.entries.len(),
+            response.total_count
+        );
+        for entry in response.entries {
+            println!("ID:        {}", entry.id);
+            println!("Timestamp: {}", entry.timestamp);
+            println!("Action:    {}", entry.action);
+            println!("Resource:  {} ({})", entry.resource_type, entry.resource_id);
+            println!("Result:    {}", entry.result);
+            if let Some(reason) = entry.reason {
+                println!("Reason:    {}", reason);
+            }
+            println!();
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn cmd_audit_get(
+    server: &str,
+    tls_ca_cert: Option<&std::path::Path>,
+    workspace_name: &str,
+    audit_log_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (mut client, principal) = setup_client(server, tls_ca_cert).await?;
+
+    let mut request = tonic::Request::new(zopp_proto::GetAuditLogRequest {
+        workspace_name: workspace_name.to_string(),
+        audit_log_id: audit_log_id.to_string(),
+    });
+    add_auth_metadata(&mut request, &principal, "/zopp.ZoppService/GetAuditLog")?;
+
+    let entry = client.get_audit_log(request).await?.into_inner();
+
+    println!("ID:           {}", entry.id);
+    println!("Timestamp:    {}", entry.timestamp);
+    println!("Principal ID: {}", entry.principal_id);
+    if let Some(user_id) = entry.user_id {
+        println!("User ID:      {}", user_id);
+    }
+    println!("Action:       {}", entry.action);
+    println!(
+        "Resource:     {} ({})",
+        entry.resource_type, entry.resource_id
+    );
+    if let Some(workspace_id) = entry.workspace_id {
+        println!("Workspace:    {}", workspace_id);
+    }
+    if let Some(project_id) = entry.project_id {
+        println!("Project:      {}", project_id);
+    }
+    if let Some(environment_id) = entry.environment_id {
+        println!("Environment:  {}", environment_id);
+    }
+    println!("Result:       {}", entry.result);
+    if let Some(reason) = entry.reason {
+        println!("Reason:       {}", reason);
+    }
+    if let Some(details) = entry.details {
+        println!("Details:      {}", details);
+    }
+    if let Some(client_ip) = entry.client_ip {
+        println!("Client IP:    {}", client_ip);
+    }
+
+    Ok(())
+}
+
+pub async fn cmd_audit_count(
+    server: &str,
+    tls_ca_cert: Option<&std::path::Path>,
+    workspace_name: &str,
+    action: Option<&str>,
+    result: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (mut client, principal) = setup_client(server, tls_ca_cert).await?;
+
+    let mut request = tonic::Request::new(zopp_proto::CountAuditLogsRequest {
+        workspace_name: workspace_name.to_string(),
+        principal_id: None,
+        user_id: None,
+        project_name: None,
+        environment_name: None,
+        action: action.map(|s| s.to_string()),
+        result: result.map(|s| s.to_string()),
+        from_timestamp: None,
+        to_timestamp: None,
+    });
+    add_auth_metadata(&mut request, &principal, "/zopp.ZoppService/CountAuditLogs")?;
+
+    let response = client.count_audit_logs(request).await?.into_inner();
+
+    println!("Total audit log entries: {}", response.count);
+
+    Ok(())
+}

--- a/apps/zopp-cli/src/commands/mod.rs
+++ b/apps/zopp-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit;
 pub mod diff;
 pub mod environment;
 pub mod group;
@@ -10,6 +11,7 @@ pub mod secret;
 pub mod sync;
 pub mod workspace;
 
+pub use audit::{cmd_audit_count, cmd_audit_get, cmd_audit_list};
 pub use diff::cmd_diff_k8s;
 pub use environment::{
     cmd_environment_create, cmd_environment_delete, cmd_environment_get, cmd_environment_list,

--- a/apps/zopp-cli/src/main.rs
+++ b/apps/zopp-cli/src/main.rs
@@ -8,8 +8,9 @@ mod grpc;
 mod k8s;
 
 use cli::{
-    Cli, Command, DiffCommand, EnvironmentCommand, GroupCommand, InviteCommand, PermissionCommand,
-    PrincipalCommand, ProjectCommand, SecretCommand, SyncCommand, WorkspaceCommand,
+    AuditCommand, Cli, Command, DiffCommand, EnvironmentCommand, GroupCommand, InviteCommand,
+    PermissionCommand, PrincipalCommand, ProjectCommand, SecretCommand, SyncCommand,
+    WorkspaceCommand,
 };
 use commands::*;
 use config::{resolve_context, resolve_workspace, resolve_workspace_project};
@@ -917,6 +918,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     workspace.as_deref(),
                     &project,
                     &environment,
+                )
+                .await?;
+            }
+        },
+        Command::Audit { audit_cmd } => match audit_cmd {
+            AuditCommand::List {
+                workspace,
+                action,
+                result,
+                limit,
+            } => {
+                cmd_audit_list(
+                    &cli.server,
+                    cli.tls_ca_cert.as_deref(),
+                    &workspace,
+                    action.as_deref(),
+                    result.as_deref(),
+                    Some(limit),
+                )
+                .await?;
+            }
+            AuditCommand::Get { workspace, id } => {
+                cmd_audit_get(&cli.server, cli.tls_ca_cert.as_deref(), &workspace, &id).await?;
+            }
+            AuditCommand::Count {
+                workspace,
+                action,
+                result,
+            } => {
+                cmd_audit_count(
+                    &cli.server,
+                    cli.tls_ca_cert.as_deref(),
+                    &workspace,
+                    action.as_deref(),
+                    result.as_deref(),
                 )
                 .await?;
             }

--- a/docs/docs/reference/cli/audit.md
+++ b/docs/docs/reference/cli/audit.md
@@ -40,11 +40,8 @@ zopp audit list [OPTIONS] -w <WORKSPACE>
 |--------|----------|-------------|
 | `-w, --workspace <WORKSPACE>` | Yes | Workspace name |
 | `--limit <LIMIT>` | No | Maximum entries to return (default: 50) |
-| `--offset <OFFSET>` | No | Number of entries to skip |
 | `--action <ACTION>` | No | Filter by action type |
-| `--principal <PRINCIPAL>` | No | Filter by principal ID |
-| `--since <TIMESTAMP>` | No | Filter entries after this time |
-| `--until <TIMESTAMP>` | No | Filter entries before this time |
+| `--result <RESULT>` | No | Filter by result (success/denied) |
 | `-h, --help` | No | Print help |
 
 ### Action Types
@@ -66,10 +63,19 @@ zopp audit list [OPTIONS] -w <WORKSPACE>
 ```bash
 $ zopp audit list -w mycompany --limit 10
 
-TIMESTAMP            ACTION          PRINCIPAL      RESOURCE
-2024-01-10 14:30:00  secret.read     alice@...      backend/prod/DATABASE_URL
-2024-01-10 14:25:00  secret.write    bob@...        backend/dev/API_KEY
-2024-01-10 14:20:00  permission.grant admin@...     user:charlie@...
+Audit logs (10 of 247 total):
+
+ID:        550e8400-e29b-41d4-a716-446655440000
+Timestamp: 2024-01-10T14:30:00Z
+Action:    secret.read
+Resource:  secret (backend/prod/DATABASE_URL)
+Result:    success
+
+ID:        550e8400-e29b-41d4-a716-446655440001
+Timestamp: 2024-01-10T14:25:00Z
+Action:    secret.write
+Resource:  secret (backend/dev/API_KEY)
+Result:    success
 ```
 
 ---
@@ -99,13 +105,17 @@ zopp audit get -w <WORKSPACE> <ENTRY_ID>
 ```bash
 $ zopp audit get -w mycompany 550e8400-e29b-41d4-a716-446655440000
 
-Entry ID: 550e8400-e29b-41d4-a716-446655440000
-Timestamp: 2024-01-10T14:30:00Z
-Action: secret.read
-Principal: alice@example.com (550e8400-...)
-Resource: backend/production/DATABASE_URL
-IP Address: 192.168.1.100
-User Agent: zopp-cli/1.0.0
+ID:           550e8400-e29b-41d4-a716-446655440000
+Timestamp:    2024-01-10T14:30:00Z
+Principal ID: 660e8400-e29b-41d4-a716-446655440000
+User ID:      770e8400-e29b-41d4-a716-446655440000
+Action:       secret.read
+Resource:     secret (backend/production/DATABASE_URL)
+Workspace:    880e8400-e29b-41d4-a716-446655440000
+Project:      990e8400-e29b-41d4-a716-446655440000
+Environment:  aa0e8400-e29b-41d4-a716-446655440000
+Result:       success
+Client IP:    192.168.1.100
 ```
 
 ---
@@ -124,13 +134,11 @@ zopp audit count [OPTIONS] -w <WORKSPACE>
 |--------|----------|-------------|
 | `-w, --workspace <WORKSPACE>` | Yes | Workspace name |
 | `--action <ACTION>` | No | Filter by action type |
-| `--principal <PRINCIPAL>` | No | Filter by principal ID |
-| `--since <TIMESTAMP>` | No | Filter entries after this time |
-| `--until <TIMESTAMP>` | No | Filter entries before this time |
+| `--result <RESULT>` | No | Filter by result (success/denied) |
 
 ### Example
 
 ```bash
-$ zopp audit count -w mycompany --action secret.read --since 2024-01-01
-Count: 1,247
+$ zopp audit count -w mycompany --action secret.read
+Total audit log entries: 1247
 ```


### PR DESCRIPTION
## Summary

- Implements the audit CLI commands (`list`, `get`, `count`) from PR #25
- Adds E2E tests covering all audit commands
- Adds RBAC test verifying admin-only access to audit logs
- Updates documentation to match implementation

## Changes

### CLI Commands
- `zopp audit list -w <workspace>` - List audit log entries (supports `--action`, `--result`, `--limit` filters)
- `zopp audit get -w <workspace> <entry-id>` - Get a specific audit entry by ID
- `zopp audit count -w <workspace>` - Count audit log entries (supports `--action`, `--result` filters)

### Tests
- `apps/e2e-tests/tests/audit.rs` - E2E tests for list, get, count, and filtering
- `apps/e2e-tests/tests/rbac.rs` - Added `test_audit_requires_admin` verifying:
  - Admin can access audit logs
  - Write role cannot access audit logs
  - Read role cannot access audit logs
  - Promoted admin can access audit logs

### Documentation
- Updated `docs/docs/reference/cli/audit.md` to match actual implementation
- Added planning/implementation guidance to `CLAUDE.md`
- Added RBAC testing section to `contributing/TESTING.md`

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] `cargo test --package e2e-tests --test audit`
- [x] `cargo test --package e2e-tests --test rbac -- test_audit_requires_admin`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds audit CLI commands (list, get, count) for workspace audit logs with filtering and clear output. Enforces admin-only access, adds E2E/RBAC tests, and updates the CLI docs.

- **New Features**
  - zopp audit list -w <workspace> [--action] [--result] [--limit]
  - zopp audit get -w <workspace> <entry-id>
  - zopp audit count -w <workspace> [--action] [--result]

- **Tests**
  - E2E coverage for list, get, count, and filtering
  - RBAC test: admin allowed; write/read denied; promoted admin allowed

<sup>Written for commit b254165664082c84eb5d80bff25545ccfac1bbe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

